### PR TITLE
Fixing travis so it can build (#17)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
-dist: xenial # (16.04)
-# bionic (18.04) is not yet available in travis
+dist: bionic # (18.04)
 
 language: cpp
 
@@ -27,6 +26,7 @@ jobs:
       before_install:
         - cd ..
         - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
         - cd azerothcore-wotlk
         - source ./apps/ci/ci-before_install.sh
       install:
@@ -54,6 +54,7 @@ jobs:
       before_install:
         - cd ..
         - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
         - cd azerothcore-wotlk
         - source ./apps/ci/ci-before_install.sh
       install:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+ [English](README.md) | [Español](README_ES.md)
 # PART 1 - How to create your own module
 
 [ THIS README IS A WORK IN PROGRESS ]
@@ -58,7 +59,5 @@ If you need to change the module configuration, go to your server configuration 
 ## Credits
 
 * [Me](https://github.com/YOUR_GITHUB_NAME) (author of the module): Check out my soundcloud - Join my discord
-* [BarbzYHOOL](https://github.com/barbzyhool): best guy <!-- you can remove this small joke or modify it, but if you let the names, we get notified when a new module is made, which is quite cool) -->
-* [Talamortis](https://github.com/talamortis): almost best guy <!-- you can remove this small joke or modify it, but if you let the names, we get notified when a new module is made, which is quite cool) -->
 
 AzerothCore: [repository](https://github.com/azerothcore) - [website](http://azerothcore.org/) - [discord chat community](https://discord.gg/PaqQRkd)

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,0 +1,66 @@
+ [English](README.md) | [Español](README_ES.md)
+
+# PARTE 1 - Cómo crear su propio módulo
+
+Puede utilizar estos scripts para iniciar su proyecto:
+
+[Ejemplos de scripts](https://github.com/azerothcore/azerothcore-boilerplates)
+
+### ¿Cómo probar su módulo?
+
+Desactivar PCH (cabeceras pre-compiladas) e intentar compilar. Si ha olvidado algunas cabeceras, es hora de añadirlas. Para desactivar PCH, siga este [link](https://github.com/azerothcore/azerothcore-wotlk/wiki/CMake-options) y ponga `USE_COREPCH ` a 0 con Cmake.
+
+-------------------------------------------------------
+
+# PARTE 2 - EJEMPLO DE UN README.md
+Recuerde que el README.md le explica al resto de las personas que es lo que hace su módulo. Recomendamos escribirlo en ingles quizás, aunque puede ser traducido luego a otros idiomas.
+
+# MI NUEVO MÓDULO (título)
+
+## Descripción
+
+Este módulo permite hacer esto y esto.
+(Debe explicar para que se va a utilizar el modulo, cuál es su utilidad)
+
+## Cómo utilizar
+
+Haz esto y aquello.
+
+Puedes agregar una carpeta de pantalla:
+
+[screenshot](/screenshots/my_module.png?raw=true "screenshot")
+
+O incluso un video donde expliques su uso:
+
+[Youtube](https://www.youtube.com/watch?v=T6UEX47mPeE)
+
+
+## Requisitos
+
+Se debe especificar que versión de azerothcore requiere, porque podría ser incompatible con alguna más adelante. Entonces aclarar por las dudas su compatibilidad no está de más.
+
+Mi nuevo módulo requiere:
+
+- AzerothCore v1.0.1+
+
+
+## Instalación
+
+```
+1) Simplemente coloque el módulo dentro del directorio `modules` de AzerothCore (repositorio), no la compilación.
+2) Importe el SQL manualmente a la base de datos correcta (auth, mundo o caracteres) o con el `db_assembler.sh` (si se proporciona `include.sh`).
+3) Vuelva a ejecutar el Cmake y genere la compilación necesaria. (Revise la guía)
+```
+
+## Editar la configuración del módulo (opcional)
+
+Si necesita cambiar la configuración del módulo, vaya a la carpeta de configuración de su servidor (donde está su `worldserver` o `worldserver.exe`), copie `my_module.conf.dist` a `my_module.conf` y edite ese nuevo archivo.
+
+
+## Créditos
+
+* [Yo](https://github.com/YOUR_GITHUB_NAME) (autor del módulo) Edite el enlace para que apunte a su github si lo desea.
+* [BarbzYHOOL](https://github.com/barbzyhool) <!-- Puedes eliminar estas líneas, pero al crear un nuevo modulo, es notificado a estas personas, por lo que está bueno que eso ocurra. -->
+* [Talamortis](https://github.com/talamortis)<!-- Puedes eliminar estas líneas, pero al crear un nuevo modulo, es notificado a estas personas, por lo que está bueno que eso ocurra. -->
+
+AzerothCore: [repository](https://github.com/azerothcore) - [website](http://azerothcore.org/) - [discord chat community](https://discord.gg/PaqQRkd)

--- a/src/MyPlayer.cpp
+++ b/src/MyPlayer.cpp
@@ -4,7 +4,8 @@
 
 #include "ScriptMgr.h"
 #include "Player.h"
-#include "Configuration/Config.h"
+#include "Config.h"
+#include "Chat.h"
 
 class MyPlayer : public PlayerScript{
 public:


### PR DESCRIPTION
* chore(CI): add module to the cache preparation (#9)

Add the module to the cache preparation. Although this is not necessary for most of the modules it is at least necessary for the eluna module. This PR is just about harmonizing the Travis configuration for all modules.

* fix: Include Chat.h so module would compile when NOPCH is used (#10)

Added include for Chat.h so module would compile when NOPCH was used (#10)
So when you take this module as a template, you don't miss any header :)

* docs: Add README.md in Spanish (#11)

* fix: Path to Config.h

Only need the file name.

* chore(CI): Update Travis configuration to use Ubuntu (#13)

* chore: Remove useless lines from README.md

* Adding support for db_assembler

* Update conf.sh.dist

* Fixing Travis

* Delete conf.sh.dist

Co-authored-by: Stoabrogga <38475780+Stoabrogga@users.noreply.github.com>
Co-authored-by: sluggor <50815505+sluggor@users.noreply.github.com>
Co-authored-by: Walter Pagani <paganiwalter@gmail.com>
Co-authored-by: Barbz <BarbzYHOOL@users.noreply.github.com>
Co-authored-by: Micrah <44911744+milestorme@users.noreply.github.com>